### PR TITLE
Update to work with latest analyzer.

### DIFF
--- a/analyzer_plugin/pubspec.yaml
+++ b/analyzer_plugin/pubspec.yaml
@@ -5,7 +5,7 @@ environment:
   sdk: '>=1.9.0 <2.0.0'
 dependencies:
   analyzer: '^0.26.1+2'
-  plugin: '^0.1.0'
+  plugin: '^0.2.0'
   html: '^0.12.2'
 dev_dependencies:
   test_reflective_loader: '^0.0.3'

--- a/server_plugin/lib/src/analysis.dart
+++ b/server_plugin/lib/src/analysis.dart
@@ -16,19 +16,21 @@ import 'package:angular2_analyzer_plugin/src/tasks.dart';
 class AnalysisDomainContributor {
   AnalysisDomain analysisDomain;
 
-  void onResult(ComputedResult result) {
-    AnalysisContext context = result.context;
-    Source source = result.target.source;
-    analysisDomain.scheduleNotification(
-        context, source, protocol.AnalysisService.NAVIGATION);
-    analysisDomain.scheduleNotification(
-        context, source, protocol.AnalysisService.OCCURRENCES);
+  void onResult(ResultChangedEvent event) {
+    if (event.wasComputed) {
+      AnalysisContext context = result.context;
+      Source source = result.target.source;
+      analysisDomain.scheduleNotification(
+          context, source, protocol.AnalysisService.NAVIGATION);
+      analysisDomain.scheduleNotification(
+          context, source, protocol.AnalysisService.OCCURRENCES);
+    }
   }
 
   void setAnalysisDomain(AnalysisDomain analysisDomain) {
     this.analysisDomain = analysisDomain;
-    analysisDomain.onResultComputed(DART_TEMPLATES).listen(onResult);
-    analysisDomain.onResultComputed(HTML_TEMPLATES).listen(onResult);
+    analysisDomain.onResultChanged(DART_TEMPLATES).listen(onResult);
+    analysisDomain.onResultChanged(HTML_TEMPLATES).listen(onResult);
   }
 }
 

--- a/server_plugin/pubspec.yaml
+++ b/server_plugin/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   angular2_analyzer_plugin:
     path: ../analyzer_plugin
   analysis_server: any
-  plugin: '^0.1.0'
+  plugin: '^0.2.0'
 dev_dependencies:
   test_reflective_loader: '^0.0.3'
   typed_mock: '^0.0.4'


### PR DESCRIPTION
Use AnalysisDomain.onResultChanged instead of onResultComputed.
Update dependency on package plugin to match that of the latest analyzer.