### PR TITLE
Fix an exception when processing local variables in templates.

### DIFF
--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -564,7 +564,12 @@ class TemplateResolver {
         new LocalVariableElementImpl(name, offset);
     localVariable.nameLength;
     localVariable.type = type;
-    htmlMethodElement.encloseElement(localVariable);
+
+    // add the local variable to the enclosing element
+    var localVariables = new List<LocalVariableElement>();
+    localVariables.addAll(htmlMethodElement.localVariables);
+    localVariables.add(localVariable);
+    htmlMethodElement.localVariables = localVariables;
     return localVariable;
   }
 


### PR DESCRIPTION
The newly created local variable needs to be added to the localVariables list of the enclosing element or it would cause an exception later while getting its hash code(for putting in a map) later.

Fixes 12 of the 14 failing tests.